### PR TITLE
Remove warning : 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'

### DIFF
--- a/nixosModule.nix
+++ b/nixosModule.nix
@@ -7,7 +7,7 @@
 }:
 let
   cfg = config.programs.eden;
-  edenPkg = self.outputs.packages.${pkgs.system}.default;
+  edenPkg = self.outputs.packages.${pkgs.stdenv.hostPlatform.system}.default;
 in
 {
   options.programs.eden = {


### PR DESCRIPTION
Hello

Small update to fix an evaluation warning.

More info here: https://discourse.nixos.org/t/how-to-fix-evaluation-warning-system-has-been-renamed-to-replaced-by-stdenv-hostplatform-system/72120

Thanks